### PR TITLE
[skip ci]Fix deplicated

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,7 @@ pygmentsCodefences = true
   site = "https://twitter.com/_kseki"
 
 [languages]
-  [languages.ja]
+  [languages.ja.params]
     title = "Klog"
     subtitle = ""
     keywords = ""


### PR DESCRIPTION
Fix errors.
```
ERROR deprecated: config: languages.ja.readmore: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.ja.centertheme: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.ja.subtitle: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.ja.keywords: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.ja.menumore: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.ja.readotherposts: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.ja.fullwidththeme: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.125.0. Put the value below [languages.ja.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

```