### PR TITLE
fix: サーチコンソールで指摘されたリンク切れを修正

### DIFF
--- a/content/post/lazygit/index.md
+++ b/content/post/lazygit/index.md
@@ -1,7 +1,7 @@
 ---
 title: 便利なGitコマンドラインツールLazygit
 description: Lazygitは、開発者の生産性を向上させるために設計された、コマンドラインツールです。このツールは、Gitの操作を簡単かつ効率的に行うことができるインターフェースを提供します。ステータスの確認、コミットの作成、ブランチの切り替えなどの一般的なGit操作を簡単に行うことができます。
-slug: lazygit
+slug: how_to_lazygit
 date: 2024-06-18T16:21:07+09:00
 image: lazygit.png
 categories: 

--- a/content/post/vim-ale-rubocop/index.md
+++ b/content/post/vim-ale-rubocop/index.md
@@ -1,7 +1,7 @@
 ---
 title: NeovimでALEを使ってDocker Compose上でRubocopを実行する
 description: Neovim(Vim) + ALEを使ってDocker Compose上でRubocopを実行する方法
-slug: vim-ale-rubocop
+slug: ale-vim-rubocop-on-docker-compose
 date: 2022-01-20
 image: vim-ale-rubocop.png
 categories:


### PR DESCRIPTION
- lazygitのスラッグをhow_to_lazygitに変更
- vim-ale-rubocopのスラッグをale-vim-rubocop-on-docker-composeに変更