### PR TITLE
chore: hugo-theme-stackをv3.27.0にアップデート

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module kseki.github.io
 
 go 1.22.5
 
-require github.com/CaiJimmy/hugo-theme-stack/v3 v3.26.0 // indirect
+require github.com/CaiJimmy/hugo-theme-stack/v3 v3.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/CaiJimmy/hugo-theme-stack/v3 v3.26.0 h1:kLZSTvo+E3S2YWw59DjXWtKLNbw3JaL7Z+VAjcegqa0=
-github.com/CaiJimmy/hugo-theme-stack/v3 v3.26.0/go.mod h1:IPmCXiIxlFSLFYS0tOmYP6ySLviyeNVSabyvSuaxD+I=
+github.com/CaiJimmy/hugo-theme-stack/v3 v3.27.0 h1:wVAa/ZimTOkFy/mODH5RXS3R3mlgfAXaDTYs7GccJUw=
+github.com/CaiJimmy/hugo-theme-stack/v3 v3.27.0/go.mod h1:IPmCXiIxlFSLFYS0tOmYP6ySLviyeNVSabyvSuaxD+I=


### PR DESCRIPTION
次のバージョンがリリースされていたので最新化
https://github.com/CaiJimmy/hugo-theme-stack/releases/tag/v3.27.0