### PR TITLE
fix: paginate を pagination.pagerSize に変更

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -2,7 +2,8 @@ baseurl = "https://kseki.github.io/"
 title = "Klog"
 languageCode = "ja-jp"
 defaultContentLanguage = "ja"
-paginate = 5
+[pagination]
+pagerSize = 5
 copyright = "kseki"
 
 enableRobotsTXT = true


### PR DESCRIPTION
## Summary

- Hugo v0.128.0 でトップレベルの `paginate` キーが削除されたため、`[pagination]` セクションの `pagerSize` に変更

## 変更内容

`config/_default/config.toml`

```diff
-paginate = 5
+[pagination]
+pagerSize = 5
